### PR TITLE
Fix `git fetch` command on development workflow documentation

### DIFF
--- a/doc/devel/development_workflow.rst
+++ b/doc/devel/development_workflow.rst
@@ -36,7 +36,7 @@ workflow is:
 
 #. Fetch all changes from ``upstream/main``::
 
-    git fetch upstream/main
+    git fetch upstream
 
 #. Start a new *feature branch* from ``upstream/main``::
 


### PR DESCRIPTION
This PR fixes a single one line mistake introduced recently in the documentation (if you think it is necessary to open an issue, and improve the description of the PR just let me know).

The problem is the following: , the Development workflow documentation is using `git fetch` the wrong way on the main brainch (since version 3.10). I stumbled upon it by trying to create a dev environment. The fix is easy, but a new contributor or a person without proper git knowledge could potentially be blocked while making a new contribution.

Currently it is indicating the command below (with the error message listed): 
```bash
matplotlib on  fix_doc:main via 🐍 v3.10.12 (env) 
❯ git fetch upstream/main
fatal: 'upstream/main' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```
while it should have been simply `git fetch upstream`. 

Note that this mistake was introduced when docs where refactored from 3.9 to 3.10. The command is just correct on version 3.9.

Regards
